### PR TITLE
setTimeout - TypeError: callback not a function

### DIFF
--- a/lib/tools/replset_manager.js
+++ b/lib/tools/replset_manager.js
@@ -240,7 +240,9 @@ var ReplSetManager = function(replsetOptions) {
 
     queryServer(members, function() {
       if (foundPrimary) return callback(null, null);
-      setTimeout(ensureIsMasterUp(configSet, callback));
+      setTimeout(function() {
+        ensureIsMasterUp(configSet, callback);
+      });
     });
   };
 


### PR DESCRIPTION
This PR resolves an error which I have seen when running the tests downstream in [MongoDB Runner](https://github.com/mongodb-js/runner) on macOS 10.12 Sierra and Ubuntu 14.04 Trusty:

<img width="1057" alt="typeerror callback must be a function - npm test - ubuntu 14 04 - screen shot 2017-06-02 at 2 45 15 pm" src="https://cloud.githubusercontent.com/assets/1217010/26713823/dded3842-47b1-11e7-8ec6-dbdaa23c6594.png">
